### PR TITLE
Bugfix/weather forecast

### DIFF
--- a/Modules/TimeAndWeather.js
+++ b/Modules/TimeAndWeather.js
@@ -138,13 +138,15 @@ function getForecast() {
 		 if(!period) continue; // unexpected forecast markup
 		 // Only want full day forecasts, throw out the evening forecasts.
 		 if(period.indexOf('Night') != -1) continue;
+         // Get the short description
+         var shortDesc = forecastDoc.window.document.querySelector('p.short-desc')?.innerHTML;
          var temp = forecastDoc.window.document.querySelector('p.temp')?.innerHTML;
          // Have to make this pretty: Partly Sunny</p><p class="temp temp-high">High: 72 &deg;F</p>
    		 // Get rid of the 'high' and 'low' labels to save space.
 		 temp = temp.replace('High: ','');
 		 temp = temp.replace('Low: ','');
-		 // get rid of extra spaces.
-		 temp = temp.replace('  ',' ');
+		 temp = (shortDesc ?? '').concat(' ' + temp);
+         temp = stripTags(temp,[],' ');
 		 writeCell(0,row,'{r}' + period + ' {g}' + temp + PADDING);
 		 row++;
 		}

--- a/Modules/TimeAndWeather.js
+++ b/Modules/TimeAndWeather.js
@@ -546,9 +546,9 @@ function clearAnimation() {
 clearBoard(4);
 clearBoard(5);
 updateTime();
-// getWeather();  BUGGY?!
+getWeather();
 getForecast();
 setInterval(updateTime, 10 * 1000); // 10 seconds
-// setInterval(getWeather, 1000 * 60 * 1); // 5 minutes
+setInterval(getWeather, 1000 * 60 * 1); // 5 minutes
 setInterval(getForecast, 1000 * 60 * 1); // 5 minutes
 setInterval(drawWeather, 4000); // increased from 1 second to share redraws a bit more

--- a/Modules/TimeAndWeather.js
+++ b/Modules/TimeAndWeather.js
@@ -132,21 +132,21 @@ function getForecast() {
 		var row = 5;
 		// Go through each of our forecasts and 
 		for(var i=0;i<forecasts.length;i++){
-         var forecastDoc = new domParser.JSDOM(forecasts[i]);
+		 var forecastDoc = new domParser.JSDOM(forecasts[i]);
 		 // Find the period of the forecast - 'Today', 'Sunday' Tonight, etc.
-         var period = forecastDoc.window.document.querySelector('p.period-name')?.innerHTML;
+		 var period = forecastDoc.window.document.querySelector('p.period-name')?.innerHTML;
 		 if(!period) continue; // unexpected forecast markup
 		 // Only want full day forecasts, throw out the evening forecasts.
 		 if(period.indexOf('Night') != -1) continue;
-         // Get the short description
-         var shortDesc = forecastDoc.window.document.querySelector('p.short-desc')?.innerHTML;
-         var temp = forecastDoc.window.document.querySelector('p.temp')?.innerHTML;
-         // Have to make this pretty: Partly Sunny</p><p class="temp temp-high">High: 72 &deg;F</p>
-   		 // Get rid of the 'high' and 'low' labels to save space.
+		 // Get the short description
+		 var shortDesc = forecastDoc.window.document.querySelector('p.short-desc')?.innerHTML;
+		 var temp = forecastDoc.window.document.querySelector('p.temp')?.innerHTML;
+		 // Have to make this pretty: Partly Sunny</p><p class="temp temp-high">High: 72 &deg;F</p>
+		 // Get rid of the 'high' and 'low' labels to save space.
 		 temp = temp.replace('High: ','');
 		 temp = temp.replace('Low: ','');
 		 temp = (shortDesc ?? '').concat(' ' + temp);
-         temp = stripTags(temp,[],' ');
+		 temp = stripTags(temp,[],' ');
 		 writeCell(0,row,'{r}' + period + ' {g}' + temp + PADDING);
 		 row++;
 		}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "html-encoder-decoder": "*",
     "ical": "*",
     "jade": "*",
+    "jsdom": "^24.1.0",
     "request": "2.x",
-    "sleep": "1.1.x",
     "striptags": "*",
     "twitter": "1.2.5",
     "xml-digester": "*"


### PR DESCRIPTION
Something changed in the weather.gov markup - the temperatures were no longer displaying.

I tried to make sense of the existing string parsing logic, but I'm at a loss not having the previous HTML from weather.gov. I feel it makes the most sense to parse each forecast into its own document fragment. This way query selectors can be used to grab the values needed. I added the jsdom package to do this.

For each "forecast" fragment:
- "Period Name" criteria is a paragraph containing class "period-name"
- Short description criteria is a paragraph containing class "short-desc", precedes temp
- High/Low temperature criteria is a paragraph containing class "temp"

The "sleep" package is not used so I removed it from the package.json.